### PR TITLE
Update to 2.0.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "Flask" %}
-{% set version = "2.0.1" %}
+{% set version = "2.0.2" %}
 
 package:
   name: {{ name|lower }}
@@ -8,10 +8,11 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 1c4c257b1892aec1398784c63791cbaa43062f1f7aeb555c4da961b20ee68f55
+  sha256: 7b2fb8e934ddd50731893bdcdb00fc8c0315916f9fcd50d22c7cc1a95ab634e2
 
 build:
   number: 0
+  skip: True  # [py<36]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
   entry_points:
     - flask = flask.cli:main
@@ -23,9 +24,8 @@ requirements:
     - pip
     - setuptools
     - wheel
-
   run:
-    - python
+    - python >=3.6
     - click >=7.1.2
     - itsdangerous >=2.0
     - jinja2 >=3.0
@@ -34,6 +34,7 @@ requirements:
 test:
   requires:
     - pip
+    - python <3.10
   imports:
     - flask
     - flask.json


### PR DESCRIPTION
Category:  anaconda | subcategory:  core | pkg_type:  python
Popularity:  2324374 downloads -  flask  2.0.2  A microframework based on Werkzeug, Jinja2 and good intentions.
Version change: bump version number from 2.0.1 to 2.0.2
  license: BSD 3-Clause
Release date:  Oct 4, 2021
Bug Tracker: new open issues https://github.com/pallets/flask/issues
Github releases:  https://github.com/pallets/flask/releases
Upstream License: https://github.com/pallets/flask/blob/main/LICENSE.rst
Upstream Changelog: mainly, bugfixes https://flask.palletsprojects.com/en/2.0.x/changes/#version-2-0-2
Upstream setup.cfg:  https://github.com/pallets/flask/blob/2.0.2/setup.cfg
Upstream setup.py:  https://github.com/pallets/flask/blob/2.0.2/setup.py

The package flask is mentioned inside the packages:
airflow | blaze | connexion | cubes | dash | flask | flask-admin | flask-appbuilder | flask-apscheduler | flask-babel | flask-bcrypt | flask-caching | flask-compress | flask-cors | flask-json | flask-jwt-extended | flask-login | flask-login-0.4.1 | flask-openid | flask-restful | flask-restx | flask-socketio | flask-sqlalchemy | flask-swagger | flask-wtf | locustio | moto | quiver_engine | tranquilizer |

Actions:
1. Update version and sha256
2. Add `skip: True  # [py<36]`
3. Update `python >=3.6` in the run section
4. Add `python <3.10` in test/requires

Result:
- all-succeeded