### PR TITLE
flask 2.0.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "Flask" %}
-{% set version = "2.0.2" %}
+{% set version = "2.0.3" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 7b2fb8e934ddd50731893bdcdb00fc8c0315916f9fcd50d22c7cc1a95ab634e2
+  sha256: e1120c228ca2f553b470df4a5fa927ab66258467526069981b3eb0a91902687d
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,17 +34,15 @@ requirements:
 test:
   requires:
     - pip
-    - python <3.10
   imports:
     - flask
     - flask.json
-
   commands:
     - flask --help
     - pip check
 
 about:
-  home: http://flask.pocoo.org
+  home: https://flask.pocoo.org
   license: BSD 3-Clause
   license_family: BSD
   license_file: LICENSE.rst


### PR DESCRIPTION
Update flask to 2.0.3

Bug Tracker: new open issues https://github.com/pallets/flask/issues
Github releases: https://github.com/pallets/flask/releases
Upstream License: https://github.com/pallets/flask/blob/main/LICENSE.rst
Upstream Changelog: mainly, bugfixes https://flask.palletsprojects.com/en/2.0.x/changes/#version-2-0-3
Upstream setup.cfg: https://github.com/pallets/flask/blob/2.0.3/setup.cfg
Upstream setup.py: https://github.com/pallets/flask/blob/2.0.3/setup.py

Actions:
1. Remove python <3.10 from test/requires
2. Fix home url with HTTPS