### PR TITLE
update_2.1.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,22 +15,21 @@ build:
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
   entry_points:
     - flask = flask.cli:main
-  noarch: python
 
 requirements:
   host:
-    - python >=3.7
+    - python
     - pip
     - setuptools
-
+    - wheel
   run:
-    - python >=3.7
+    - python
     - click >=8.0
     # should be py<310 but we want to keep this noarch: python
     - importlib-metadata  >=3.6.0
     - itsdangerous >=2.0
     - jinja2 >=3.0
-    - werkzeug >=2.0
+    - werkzeug >=2.2.0
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - importlib-metadata  >=3.6.0
     - itsdangerous >=2.0
     - jinja2 >=3.0
-    - werkzeug >=2.2.0
+    - werkzeug >=2.0
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "Flask" %}
-{% set version = "2.0.3" %}
+{% set version = "2.1.3" %}
 
 package:
   name: {{ name|lower }}
@@ -8,11 +8,10 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: e1120c228ca2f553b470df4a5fa927ab66258467526069981b3eb0a91902687d
+  sha256: 15972e5017df0575c3d6c090ba168b6db90259e620ac8d7ea813a396bad5b6cb
 
 build:
   number: 0
-  skip: True  # [py<36]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
   entry_points:
     - flask = flask.cli:main
@@ -20,13 +19,15 @@ build:
 
 requirements:
   host:
-    - python
+    - python >=3.7
     - pip
     - setuptools
-    - wheel
+
   run:
-    - python >=3.6
-    - click >=7.1.2
+    - python >=3.7
+    - click >=8.0
+    # should be py<310 but we want to keep this noarch: python
+    - importlib-metadata  >=3.6.0
     - itsdangerous >=2.0
     - jinja2 >=3.0
     - werkzeug >=2.0
@@ -42,18 +43,23 @@ test:
     - pip check
 
 about:
-  home: https://flask.pocoo.org
-  license: BSD 3-Clause
+  home: https://palletsprojects.com/p/flask
+  license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.rst
-  summary: A microframework based on Werkzeug, Jinja2 and good intentions.
+  summary: A simple framework for building complex web applications.
   description: |
-    Flask is a microframework for Python based on Werkzeug and Jinja2. It's
-    intended for getting started very quickly and was developed with best
-    intentions in mind.
-  doc_url: https://flask.palletsprojects.com/en/2.0.x/
-  doc_source_url: https://github.com/pallets/flask/blob/master/docs/index.rst
-  dev_url: https://github.com/pallets/flask
+    Flask is a lightweight [WSGI](https://wsgi.readthedocs.io/) web application framework. It is designed
+    to make getting started quick and easy, with the ability to scale up to
+    complex applications. It began as a simple wrapper around [Werkzeug](https://werkzeug.palletsprojects.com/)
+    and [Jinja](https://jinja.palletsprojects.com/) and has become one of the most popular Python web
+    application frameworks.
+    Flask offers suggestions, but doesn't enforce any dependencies or
+    project layout. It is up to the developer to choose the tools and
+    libraries they want to use. There are many extensions provided by the
+    community that make adding new functionality easy.
+  doc_url: https://flask.palletsprojects.com/
+  dev_url: https://github.com/pallets/flask/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
 
 build:
   number: 0
+  skip: True # [py<37]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
   entry_points:
     - flask = flask.cli:main
@@ -25,8 +26,7 @@ requirements:
   run:
     - python
     - click >=8.0
-    # should be py<310 but we want to keep this noarch: python
-    - importlib-metadata  >=3.6.0
+    - importlib-metadata >=3.6.0  # [py<310]
     - itsdangerous >=2.0
     - jinja2 >=3.0
     - werkzeug >=2.0


### PR DESCRIPTION
Version bump from 2.0.3 to 2.1.3:
Changelog: https://github.com/pallets/flask/blob/main/CHANGES.rst
- removed `noarch: python`
- Removed version pinning from python 
https://github.com/AnacondaRecipes/flask-feedstock/blob/eb8b55908b096b4c35c505e1724cd9aab792ac9c/recipe/meta.yaml#L28
- updated the description