### PR TITLE
Update 1.1.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "Flask" %}
-{% set version = "2.2.2" %}
+{% set version = "1.1.4" %}
 
 package:
   name: {{ name|lower }}
@@ -8,11 +8,11 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 642c450d19c4ad482f96729bd2a8f6d32554aa1e231f4f6b4e7e5264b16cca2b
+  sha256: 0fbeb6180d383a9186d0d6ed954e0042ad9f18e0e8de088b2b419d526927d196
 
 build:
   number: 0
-  skip: True  # [py<37]
+  skip: True  # [py<35]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
   entry_points:
     - flask = flask.cli:main
@@ -25,11 +25,10 @@ requirements:
     - wheel
   run:
     - python
-    - click >=8.0
-    - importlib-metadata >=3.6.0  # [py<310]
-    - itsdangerous >=2.0
-    - jinja2 >=3.0
-    - werkzeug >=2.2.2
+    - click >=5.1,<8.0
+    - itsdangerous >=0.24,<2.0
+    - jinja2 >=2.10.1,<3.0
+    - werkzeug >=0.15,<2.0
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,19 +12,19 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<35]
+  noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
   entry_points:
     - flask = flask.cli:main
 
 requirements:
   host:
-    - python
+    - python >=3.5
     - pip
     - setuptools
     - wheel
   run:
-    - python
+    - python >=3.5
     - click >=5.1,<8.0
     - itsdangerous >=0.24,<2.0
     - jinja2 >=2.10.1,<3.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,6 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.rst
-  license_url: https://github.com/pallets/flask/blob/main/LICENSE.rst
   summary: A simple framework for building complex web applications.
   description: |
     Flask is a lightweight [WSGI](https://wsgi.readthedocs.io/) web application framework. It is designed

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,7 +56,7 @@ about:
     project layout. It is up to the developer to choose the tools and
     libraries they want to use. There are many extensions provided by the
     community that make adding new functionality easy.
-  doc_url: https://flask.palletsprojects.com/
+  doc_url: https://flask.palletsprojects.com/en/1.1.x/
   dev_url: https://github.com/pallets/flask/
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   host:
-    - python >=3.5
+    - python
     - pip
     - setuptools
     - wheel


### PR DESCRIPTION
Related to [PKG-1117](https://anaconda.atlassian.net/jira/software/c/projects/PKG/issues/PKG-1117)

flask version 1.1.x is still used. Dependency pinnings contain no upper bound, but the newest versions are not compatible with `flask 1.1.x`.

Upstream: https://github.com/pallets/flask/tree/1.1.4

# Changes

* Update flask v1.1.x to v1.1.4.

# Notes

* Currently existing artifacts will be fixed in a repodata hotfix: https://github.com/AnacondaRecipes/repodata-hotfixes/pull/184
* The package will stay noarch to keep with other 1.1.x builds.