### PR TITLE
flask 3.0.3

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,3 @@
 channels:
   - https://staging.continuum.io/prefect/fs/werkzeug-feedstock/pr10/32826d1
+  - https://staging.continuum.io/prefect/fs/itsdangerous-feedstock/pr4/6569ec4

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,2 @@
-aggregate_branch: 3.12
+channels:
+  - https://staging.continuum.io/prefect/fs/werkzeug-feedstock/pr10/32826d1

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/werkzeug-feedstock/pr10/32826d1
-  - https://staging.continuum.io/prefect/fs/itsdangerous-feedstock/pr4/6569ec4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set name = "Flask" %}
-{% set version = "2.2.5" %}
+{% set name = "flask" %}
+{% set version = "3.0.3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: edee9b0a7ff26621bd5a8c10ff484ae28737a2410d99b0bb9a6850c7fb977aa0
+  sha256: ceb27b0af3823ea2737928a4d99d125a06175b8512c445cbd9a9ce200ef76842
 
 build:
   number: 0
-  skip: True  # [py<37]
+  skip: True  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
   entry_points:
     - flask = flask.cli:main
@@ -20,31 +20,38 @@ requirements:
   host:
     - python
     - pip
-    - setuptools
-    - wheel
+    - flit-core <4
   run:
     - python
-    - click >=8.0
+    - blinker >=1.6.2
+    - click >=8.1.3
     - importlib-metadata >=3.6.0  # [py<310]
-    - itsdangerous >=2.0
-    - jinja2 >=3.0
-    - werkzeug >=2.2.2
+    - itsdangerous >=2.1.2
+    - jinja2 >=3.1.2
+    - werkzeug >=3.0.0
+  run_constrained:
+    - asgiref >=3.2
 
 test:
-  requires:
-    - pip
   imports:
     - flask
     - flask.json
+  source_files:
+    - tests
+  requires:
+    - pip
+    - pytest
   commands:
     - flask --help
     - pip check
+    - pytest -vv
+
 
 about:
   home: https://palletsprojects.com/p/flask
   license: BSD-3-Clause
   license_family: BSD
-  license_file: LICENSE.rst
+  license_file: LICENSE.txt
   license_url: https://github.com/pallets/flask/blob/main/LICENSE.rst
   summary: A simple framework for building complex web applications.
   description: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,7 +52,6 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.txt
-  license_url: https://github.com/pallets/flask/blob/main/LICENSE.rst
   summary: A simple framework for building complex web applications.
   description: |
     Flask is a lightweight [WSGI](https://wsgi.readthedocs.io/) web application framework. It is designed


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-2305](https://anaconda.atlassian.net/browse/PKG-2305)
- release-notes: https://github.com/pallets/flask/releases
- release-diff: https://github.com/pallets/flask//compare/2.2.5...3.0.3
- changelog: https://github.com/pallets/flask/blob/main/CHANGES.rst
- license: https://github.com/pallets/flask/blob/main/LICENSE.txt
- requirements-tagged:
  - https://github.com/pallets/flask/blob/3.0.3/pyproject.toml
  - https://github.com/pallets/flask/tree/3.0.3/requirements


### Explanation of changes:

- Use `flit-core <4` in `host`
- Update runtime dependencies and pinnings
- Add `asgiref` to `run_constrained`
- Add tests
- Fix `license_file`

### Notes:

- Updating because the dependency `werkzeug 3.0.3` (the [PR](https://github.com/AnacondaRecipes/werkzeug-feedstock/pull/10)) fixes CVE-2024-34069 (Base score **7.5** - High)
- I've tested the **downstream** packages, see the [list](https://metayaml-conda.fly.dev/metayaml/reverse_dependencies?name=flask):
     **SUCCEEDED:**
     - dash 2.7.0
     - flask-apscheduler 1.12.4
     - flask-babel 2.0.0
     - flask-bcrypt 1.0.1
     - flask-caching 1.10.1
     - flask-compress 1.13
     - flask-cors 3.0.10
     - flask-restful 0.3.9
     - flask-session 0.4.0
     - flask-socketio 5.3.1
     - flask-sqlalchemy 3.0.2
     - jupyter-dash 0.4.2
     - mlflow 2.9.2
     - moto 4.1.3
     - prometheus_flask_exporter 0.22.4


    **FAILED, to be updated:**

    - `flask-wtf 1.0.1`
      - `ImportError: cannot import name 'Markup' from 'flask'`
      - Update to Flask-WTF 1.2.1 https://github.com/AnacondaRecipes/flask-wtf-feedstock/pull/3
    - `flask-json 0.3.4`
      - `AttributeError: module 'flask.json' has no attribute 'JSONEncoder' `
      - Update to Flask-JSON 0.4.0 https://github.com/AnacondaRecipes/flask-json-feedstock/pull/1
    - `flask-restx 1.0.3`
      - `ModuleNotFoundError: No module named 'flask.scaffold'`
      - Update to flask-restx 1.3.0 https://github.com/AnacondaRecipes/flask-restx-feedstock/pull/4
    - `flask-admin 1.6.0`
      - `ImportError: cannot import name '_request_ctx_stack' from 'flask.globals'`
      - Update to flask-admin 1.6.1 https://github.com/AnacondaRecipes/flask-admin-feedstock/pull/4
    - `flask-login 0.6.2`
      - `ImportError: cannot import name 'url_decode' from 'werkzeug.urls'`
      - Update to 0.6.3 https://github.com/AnacondaRecipes/flask-login-feedstock/pull/2

    **FAILED, but obsolete (no new versions)**:
```
    # Update to quilt3 5.4.0???
    # -- the package is outdated; not available on osx-arm64
    # - quilt3 3.1.10

    # Update to connexion 3.0.6???
    # - connexion 2.14.0

    # cubes has py<311 -- no new version
    #- cubes 1.1

    # ImportError: cannot import name 'url_decode' from 'werkzeug.urls'
    #- flask-openid 1.3.0  -- no new version

    # ModuleNotFoundError: No module named 'pkg_resources'
    #- flask-swagger 0.2.14 -- no new version

    # Update to tranquilizer 0.8.1??? But it has python_requires=">=3.6, <3.10"
    # tranquilizer-0.5.0-py_0 requires werkzeug >=0.15,<2.0, but none of the providers can be installed
    #- tranquilizer 0.5.0

    # package werkzeug-3.0.3-py311_0 requires python >=3.11,<3.12.0a0, but none of the providers can be installed
    #- locustio 0.14.6  -- the package is obsolete

    #-- the package is obsolete
    #- quiver_engine 0.1.4.1.4 -- no new version
```

[PKG-2305]: https://anaconda.atlassian.net/browse/PKG-2305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ